### PR TITLE
Fix syntax error in Rarities.js breaking VBRC Checker

### DIFF
--- a/src/Rarities.js
+++ b/src/Rarities.js
@@ -78,7 +78,7 @@ class NameForm extends React.Component {
         label: capitalizeFirstLetters(town)
       }
     })
-  }f
+  }
 
   render() {
     return (


### PR DESCRIPTION
## Summary

- Removes stray `f` character after the closing brace of `createTownList()` on line 81 of `src/Rarities.js`
- This was a JavaScript parse error that prevented the entire VBRC Checker page from loading

## Test plan

- [ ] Navigate to `/vbrc-checker` — page should load without errors
- [ ] Fill in Species, Town, and Date and click Submit — should return a rarity result

Closes #87