### PR TITLE
Fix deprecated componentWillMount in About.js

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -10,7 +10,7 @@ class About extends Component {
     this.state = { text: null }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const path = aboutPath
     fetch(path).then((response) => response.text()).then((text) => {
       this.setState({ text: text })


### PR DESCRIPTION
## Summary

- Renames `componentWillMount()` to `componentDidMount()` in `src/About.js`
- `componentWillMount` was deprecated in React 16.3 and removed in React 18; this eliminates the deprecation warning and makes the code future-safe

## Test plan

- [ ] Navigate to `/` or `/about` — page should load the markdown content correctly

Closes #88