### PR TITLE
Fix hardcoded year 2022 in App.js and Map.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,9 +46,10 @@ class App extends Component {
     let towns = await ebird.towns({all: true, input: e})
     let regions = await ebird.regions({all: true, input: e})
     let counties = await ebird.counties({all: true, input: e})
+    const currentYear = String(new Date().getFullYear())
     let checklists = {
-      vermont: await ebird.checklists({state: 'Vermont', year: '2022', input: e, complete: true}),
-      norwich: await ebird.checklists({town: 'Norwich', year: '2022', input: e})
+      vermont: await ebird.checklists({state: 'Vermont', year: currentYear, input: e, complete: true}),
+      norwich: await ebird.checklists({town: 'Norwich', year: currentYear, input: e})
     }
     // let radial = await ebird.radialSearch({input: e, coordinates: [44.259548, -72.575882]})
     this.setState((prevState, props) => ({

--- a/src/Map.js
+++ b/src/Map.js
@@ -113,7 +113,7 @@ class Map extends Component {
       // Sightings for the current year
       } else if (data.towns && this.state.mapView === '3') {
         // Add complete: true, duration: 3 to limit this down
-        const dataThisYear = await ebirdExt.towns({all: true, year: 2022, input: data.input})
+        const dataThisYear = await ebirdExt.towns({all: true, year: new Date().getFullYear(), input: data.input})
         totalTowns = Object.keys(dataThisYear).filter(c => dataThisYear[c].length !== 0).length
         unseenTowns = Object.keys(dataThisYear).filter(c => dataThisYear[c].length === 0)
         speciesView = Object.keys(dataThisYear).map(c => dataThisYear[c].length)
@@ -187,7 +187,7 @@ class Map extends Component {
       if (data.counties && this.state.mapView === '2') {
         speciesView = Object.keys(data.counties).map(c => data.counties[c].speciesTotal)
       } else if (data.counties && this.state.mapView === '3') {
-        const dataThisYear = await ebirdExt.counties({all: true, year: 2022, input: data.input})
+        const dataThisYear = await ebirdExt.counties({all: true, year: new Date().getFullYear(), input: data.input})
         speciesView = Object.keys(dataThisYear).map(c => dataThisYear[c].speciesTotal)
         vermont.features.forEach(feature => {
           feature.properties.species = dataThisYear[feature.properties.name].species
@@ -223,7 +223,7 @@ class Map extends Component {
       if (data.regions && this.state.mapView === '2') {
         speciesView = Object.keys(data.regions).map(region => data.regions[region].speciesTotal)
       } else if (data.regions && this.state.mapView === '3') {
-        const dataThisYear = await ebirdExt.regions({all: true, year: 2022, input: data.input})
+        const dataThisYear = await ebirdExt.regions({all: true, year: new Date().getFullYear(), input: data.input})
         speciesView = Object.keys(dataThisYear).map(r => dataThisYear[r].speciesTotal)
         vermont.features.forEach(feature => {
           feature.properties.species = dataThisYear[feature.properties.name].species


### PR DESCRIPTION
## Summary

- Replaces hardcoded `'2022'` with `new Date().getFullYear()` in `src/App.js` (checklist queries) and `src/Map.js` (towns/counties/regions current-year views)
- The "this year" map view was always showing 2022 data regardless of the actual year

## Test plan

- [ ] Upload an eBird CSV and switch to the "this year" view on `/towns`, `/counties`, `/regions` — should show the current year's data
- [ ] Norwich checklist query should use the current year

Closes #89