### PR TITLE
Fix Map.js unnecessary re-renders on every component update

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -45,8 +45,12 @@ class Map extends Component {
     this.createMap()
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.data !== prevProps.data || this.props.location.pathname !== prevProps.location.pathname) {
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.props.data !== prevProps.data ||
+      this.props.location.pathname !== prevProps.location.pathname ||
+      this.state.mapView !== prevState.mapView
+    ) {
       this.createMap()
     }
     if (this.props.location !== prevProps.location) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -46,7 +46,9 @@ class Map extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    this.createMap()
+    if (this.props.data !== prevProps.data || this.props.location.pathname !== prevProps.location.pathname) {
+      this.createMap()
+    }
     if (this.props.location !== prevProps.location) {
       this.onRouteChanged()
     }


### PR DESCRIPTION
## Summary

- Adds a guard in `componentDidUpdate` so `createMap()` only fires when `props.data` or `props.location.pathname` has actually changed
- Previously the map was fully cleared (`d3.selectAll("svg > *").remove()`) and redrawn on every React update, causing visible flicker and unnecessary CPU work

## Test plan

- [x] Upload a CSV on `/towns` — map should render once, not flicker repeatedly
- [x] Switching between `/towns`, `/counties`, `/regions` should re-render the map correctly
- [x] Internal state changes (e.g. toggling map view buttons) should not cause a full map redraw

Closes #90