### PR TITLE
Fix navbar collapse button unresponsive on mobile

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -9,11 +9,11 @@ class NavBar extends Component {
         <Link className="navbar-brand" to="/">
           Birding in Vermont
         </Link>
-        <Navbar.Toggle />
-        <Navbar.Collapse>
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="me-auto mb-2 mb-lg-0">
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/about">
+              <Nav.Link eventKey="1" as={Link} to="/about">
                 About
               </Nav.Link>
             </Nav.Item>
@@ -23,42 +23,42 @@ class NavBar extends Component {
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/counties">
+              <Nav.Link eventKey="3" as={Link} to="/counties">
               Counties
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/regions">
+              <Nav.Link eventKey="4" as={Link} to="/regions">
               Bioregions
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/nfc-species">
+              <Nav.Link eventKey="5" as={Link} to="/nfc-species">
               NFCs
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/subspecies">
+              <Nav.Link eventKey="6" as={Link} to="/subspecies">
               Subspecies
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/vbrc-checker">
+              <Nav.Link eventKey="7" as={Link} to="/vbrc-checker">
               VBRC Checker
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/female-birdsong">
+              <Nav.Link eventKey="8" as={Link} to="/female-birdsong">
                 Female Birdsong
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/251">
+              <Nav.Link eventKey="9" as={Link} to="/251">
                 Project 251
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="2" as={Link} to="/hotspots">
+              <Nav.Link eventKey="10" as={Link} to="/hotspots">
                 Unbirded Hotspots
               </Nav.Link>
             </Nav.Item>


### PR DESCRIPTION
## Summary

- Adds `aria-controls="basic-navbar-nav"` to `<Navbar.Toggle>` and matching `id="basic-navbar-nav"` to `<Navbar.Collapse>` — Bootstrap requires these to wire up the toggle
- Gives each `Nav.Link` a unique `eventKey` (1–10) so `collapseOnSelect` can identify which item was clicked and close the menu after navigation

## Test plan

- [ ] At mobile viewport width (<992px), tap the hamburger toggle — the nav links should expand and collapse
- [ ] Tapping a nav link should navigate to the page and close the menu

Closes #33