### PR TITLE
Remove debug console.log from LatLongForm.js

### DIFF
--- a/src/LatLongForm.js
+++ b/src/LatLongForm.js
@@ -15,9 +15,7 @@ class LatLongForm extends Component {
   }
 
   handleSubmit(event) {
-    // alert('A name was submitted: ' + this.state.coordinates);
     this.setState({coordinates: this.state.coordinates})
-    console.log(this.state)
     event.preventDefault();
   }
 


### PR DESCRIPTION
## Summary

- Removes `console.log(this.state)` debug statement left in `LatLongForm.js handleSubmit`
- Also removes a stale `alert()` comment on the same line

## Test plan

- [ ] Browser console should not log state on form submit

Closes #98