### PR TITLE
Remove dead commented-out code from App.js and Project251.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,6 @@ class App extends Component {
       vermont: await ebird.checklists({state: 'Vermont', year: '2022', input: e, complete: true}),
       norwich: await ebird.checklists({town: 'Norwich', year: '2022', input: e})
     }
-    // let radial = await ebird.radialSearch({input: e, coordinates: [44.259548, -72.575882]})
     this.setState((prevState, props) => ({
       data: {
         ...prevState.data,
@@ -86,7 +85,6 @@ class App extends Component {
             <Route exact path='/vbrc-checker' render={(props) =>(<Rarities {...props} data={this.state.data} handleChange={this.handleChange} />)} />
             <Route exact path='/norwich' render={(props) =>(<Norwich {...props} data={this.state.data} handleChange={this.handleChange} />)} />
             <Route exact path='/terms' render={(props) =>(<ContentPage {...props} key={randomGen()}/>)} />
-            {/* <Route exact path='/10-mile' component={RadialView} data={this.state.data.radial} /> */}
             <Route component={NoMatchPage} />
             <Redirect from="/nfc" to="/nfc-species" />
           </Switch>

--- a/src/Project251.js
+++ b/src/Project251.js
@@ -2,49 +2,9 @@ import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 import Map from './Map'
 import { withRouter } from 'react-router'
-// import UploadButton from './UploadButton'
-// import ChecklistTableRow from './Checklists'
 import { Link } from 'react-router-dom'
 const ReactMarkdown = require('react-markdown')
 const matter = require('gray-matter')
-
-
-/* function AllRows (props) {
-  let checklists = props.data
-  if (checklists.vermont.length!== 0) {
-    return (
-      <div>
-        <ChecklistTableRow title={"Your checklists"} data={checklists.vermont} text={"Here are all of your complete checklists from 2022 in Vermont."} />
-      </div>
-    )
-  } else {
-    return (
-      <div>
-        <hr />
-        <h2>You're all set!</h2>
-        <p>You haven't submitted any checklists in Vermont this year! Get out there and bird!</p>
-      </div>
-    )
-  }
-}
-
-function Checklists (props) {
-  let checklists = props.data.checklists
-  return (
-    <div id="rarities" className="container-md">
-      <div className="row">
-        {checklists !== '' ?
-          <AllRows data={checklists} /> :
-          <>
-            <p>If you're interested in contributing, this site can show you what complete checklists you've submitted in Vermont this year.  While it can't tell if you've already shared these checklists, it should help you find out which ones you should share. Open each in a new tab and ensure it has been shared with <b>vermont251</b>.</p>
-            <p>First, <a href="https://ebird.org/downloadMyData" target="_blank" rel="noopener noreferrer" >download your data from eBird.</a> Then, load the unzipped .csv file here. Your data is not stored on this site in any way.</p>
-            <UploadButton handleChange={props.handleChange} data={props.data} />
-          </>
-        }
-      </div>
-    </div>
-  )
-} */
 
 
 class Project251 extends Component {


### PR DESCRIPTION
## Summary

- `src/App.js`: removes commented-out `radialSearch` variable and the dead `/10-mile` route (no component is imported for it)
- `src/Project251.js`: removes two commented-out imports and the entire `AllRows`/`Checklists` function block that was never re-enabled

## Test plan

- [ ] `/about`, `/towns`, `/counties`, `/regions`, `/251`, `/vbrc-checker` all load correctly
- [ ] No import errors in the build

Closes #99, related to #67