### PR TITLE
Add loading spinner while eBird data is being processed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ class App extends Component {
   }
 
   async handleChange(e) {
+    this.setState(prevState => ({ data: { ...prevState.data, loading: true } }))
     let rarities = await ebird.rare({input: e}) // Input?
     let towns = await ebird.towns({all: true, input: e})
     let regions = await ebird.regions({all: true, input: e})
@@ -60,6 +61,7 @@ class App extends Component {
         counties,
         checklists,
         loaded: true,
+        loading: false,
         input: e,
         singleBirdForm: false // Toggles various forms on the Rarities pages
       }

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,10 @@ class App extends Component {
   }
 
   async handleChange(e) {
-    this.setState(prevState => ({ data: { ...prevState.data, loading: true } }))
+    await new Promise(resolve => {
+      this.setState(prevState => ({ data: { ...prevState.data, loading: true } }), resolve)
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
     let rarities = await ebird.rare({input: e}) // Input?
     let towns = await ebird.towns({all: true, input: e})
     let regions = await ebird.regions({all: true, input: e})

--- a/src/UploadButton.js
+++ b/src/UploadButton.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-// import Spinner from 'react-bootstrap/Spinner'
+import Spinner from 'react-bootstrap/Spinner'
 import CSVReader from 'react-csv-reader'
 
 const papaparseOptions = {
@@ -11,7 +11,13 @@ const papaparseOptions = {
 class UploadButton extends Component {
   render() {
     let label = (this.props.label) ? this.props.label : "Select your MyEbirdData.csv file"
-    if (!this.props.data.counties) {
+    if (this.props.data.loading) {
+      return (
+        <Spinner animation="border" role="status">
+          <span className="sr-only">Loading...</span>
+        </Spinner>
+      )
+    } else if (!this.props.data.counties) {
       return (
         <div className="container-md csv-container">
           <CSVReader
@@ -22,12 +28,6 @@ class UploadButton extends Component {
           />
         </div>
       )
-    // } else if (this.loader) {
-    //   return (
-    //     <Spinner animation="border" role="status">
-    //       <span className="sr-only">Loading...</span>
-    //     </Spinner>
-    //   )
     } else {
       return null
     }


### PR DESCRIPTION
## Summary

- Adds `loading: true` to `App.state.data` at the start of `handleChange`, cleared to `false` when all data is ready
- `UploadButton` now shows a Bootstrap `<Spinner>` while `props.data.loading` is true, replacing the file input during the processing window
- The spinner import was already present (commented out) in `UploadButton.js` — this PR wires it up properly

## Test plan

- [ ] Upload a CSV on `/towns` — a spinner should appear immediately after selecting the file
- [ ] Once data loads, the spinner should disappear and the map should update

Closes #53