### PR TITLE
Add eBird download link and file instructions to upload UI

### DIFF
--- a/src/UploadButton.js
+++ b/src/UploadButton.js
@@ -14,6 +14,12 @@ class UploadButton extends Component {
     if (!this.props.data.counties) {
       return (
         <div className="container-md csv-container">
+          <p>
+            <a href="https://ebird.org/downloadMyData" target="_blank" rel="noopener noreferrer">
+              Download your eBird data
+            </a> from ebird.org, then load the unzipped <code>MyEBirdData.csv</code> file below.
+            Your data is not stored on this site in any way.
+          </p>
           <CSVReader
             onFileLoaded={this.props.handleChange}
             label={label}


### PR DESCRIPTION
## Summary

- Adds a paragraph above the CSV file picker in `UploadButton.js` linking to https://ebird.org/downloadMyData and noting the expected filename (`MyEBirdData.csv`)
- Appears on all map pages that show the upload button (`/towns`, `/counties`, `/regions`)

## Test plan

- [ ] Navigate to `/towns` (or `/counties`, `/regions`) — should see a paragraph with a link to ebird.org/downloadMyData above the file picker

Closes #27