### PR TITLE
Fix towns map showing uniform dark color after CSV upload

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -107,9 +107,9 @@ class Map extends Component {
 
       // Your personal sightings
       if (data.towns && this.state.mapView === '2') {
-        speciesView = Object.keys(data.towns).map(c => data.towns[c].speciesTotal)
-        totalTowns = Object.keys(data.towns).filter(c => data.towns[c].speciesTotal !== 0).length
-        unseenTowns = Object.keys(data.towns).filter(c => !data.towns[c].speciesTotal)
+        speciesView = Object.keys(data.towns).map(c => data.towns[c].length)
+        totalTowns = Object.keys(data.towns).filter(c => data.towns[c].length !== 0).length
+        unseenTowns = Object.keys(data.towns).filter(c => data.towns[c].length === 0)
       // Sightings for the current year
       } else if (data.towns && this.state.mapView === '3') {
         // Add complete: true, duration: 3 to limit this down


### PR DESCRIPTION
## Summary

After uploading a CSV on `/towns`, all towns showed the same dark red color instead of a gradient by species count.

**Root cause:** Lines 110–112 read `data.towns[c].speciesTotal` to build the D3 color scale domain. But `data.towns[c]` is a plain array of species strings — it has no `.speciesTotal` property. This produces an array of `undefined`, `Math.max()` returns `NaN`, and a NaN domain causes D3's `scaleQuantize` to map every value to the last (darkest) color.

The "this year" view (lines 117–119) and the default view (line 128) correctly use `.length` on the same data structure.

**Fix:** Replace `.speciesTotal` with `.length` on lines 110–112.

## Test plan

- [ ] Upload a CSV on `/towns` — towns with more species should appear darker, towns with fewer should be lighter
- [ ] Towns with 0 species should be grey
- [ ] Hovering a town should show the correct species count in the heading

Closes #104